### PR TITLE
Add fbcdn.net domain to permissions

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -39,6 +39,7 @@
     "downloads",
     "storage",
     "*://*.instagram.com/*",
-    "*://*.cdninstagram.com/*"
+    "*://*.cdninstagram.com/*",
+    "*://*.fbcdn.net/*"
   ]
 }

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -45,6 +45,7 @@
     "downloads",
     "storage",
     "*://*.instagram.com/*",
-    "*://*.cdninstagram.com/*"
+    "*://*.cdninstagram.com/*",
+    "*://*.fbcdn.net/*"
   ]
 }


### PR DESCRIPTION
I noticed that the extension doesn't work (due to CORS) on fbcdn.net domains. This should fix the issue. I only tested this on Firefox.
Fixes #45