### PR TITLE
fix #83 and upgrade to using manifest v3

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -1,7 +1,7 @@
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
   if (changeInfo.status == 'complete') {
     if (tab.url.match('^https?://(www\.)?instagram.com*')) {
-      chrome.tabs.executeScript(tab.id, { file: 'script.js' });
+      chrome.scripting.executeScript({target: { tabId: tab.id }, files: ['script.js'] });
     }
   }
 });

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -4,7 +4,7 @@
 
   "name": "__MSG_extName__",
   "description": "__MSG_extDesc__",
-  "version": "1.27.5",
+  "version": "1.27.6",
 
   "action": {
     "default_icon": {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,12 +1,12 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "default_locale": "en",
 
   "name": "__MSG_extName__",
   "description": "__MSG_extDesc__",
   "version": "1.27.5",
 
-  "browser_action": {
+  "action": {
     "default_icon": {
       "19": "icons/icon_512.png",
       "38": "icons/icon_512.png"
@@ -20,7 +20,7 @@
   },
 
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
 
   "content_scripts": [
@@ -37,6 +37,10 @@
   "permissions": [
     "tabs",
     "downloads",
+    "scripting"
+  ],
+
+  "host_permissions": [
     "*://*.instagram.com/*",
     "*://*.cdninstagram.com/*",
     "*://*.fbcdn.net/*"

--- a/chrome/script.js
+++ b/chrome/script.js
@@ -118,10 +118,7 @@ function findMedia(box, way) {
         _username = '';
 
         articles = _parent.parents('article').concat(_parent.parents('main'));
-        if (articles[0].querySelector('.x1lliihq a[role="link"].notranslate')) {
-          _username = articles[0].querySelector('.x1lliihq a[role="link"].notranslate').text;
-        }
-        else if (articles[0].querySelector('._aaqt a[role="link"]')) {
+        if (articles[0].querySelector('._aaqt a[role="link"]')) {
           _username = articles[0].querySelector('._aaqt a[role="link"]').text;
         }
 

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -1,7 +1,7 @@
 browser.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
   if (changeInfo.status == 'complete') {
     if (tab.url.match('^https?://(www\.)?instagram.com*')) {
-      browser.tabs.executeScript(tab.id, { file: 'script.js' });
+      browser.scripting.executeScript({target: { tabId: tab.id }, files: ['script.js'] });
     }
   }
 });

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "browser_specific_settings": {
     "gecko": {
@@ -12,7 +12,7 @@
   "description": "Easily download Instagram pictures and videos.",
   "version": "1.27.5",
 
-  "browser_action": {
+  "action": {
     "default_icon": {
       "19": "icons/icon_19.png",
       "38": "icons/icon_38.png"
@@ -26,7 +26,7 @@
   },
 
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
 
   "content_scripts": [
@@ -43,6 +43,10 @@
   "permissions": [
     "tabs",
     "downloads",
+    "scripting"
+  ],
+
+  "host_permissions": [
     "*://*.instagram.com/*",
     "*://*.cdninstagram.com/*",
     "*://*.fbcdn.net/*"

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -10,7 +10,7 @@
 
   "name": "Media Helper for Instagram",
   "description": "Easily download Instagram pictures and videos.",
-  "version": "1.27.5",
+  "version": "1.27.6",
 
   "action": {
     "default_icon": {

--- a/firefox/script.js
+++ b/firefox/script.js
@@ -118,10 +118,7 @@ function findMedia(box, way) {
         _username = '';
 
         articles = _parent.parents('article').concat(_parent.parents('main'));
-        if (articles[0].querySelector('.x1lliihq a[role="link"].notranslate')) {
-          _username = articles[0].querySelector('.x1lliihq a[role="link"].notranslate').text;
-        }
-        else if (articles[0].querySelector('._aaqt a[role="link"]')) {
+        if (articles[0].querySelector('._aaqt a[role="link"]')) {
           _username = articles[0].querySelector('._aaqt a[role="link"]').text;
         }
 


### PR DESCRIPTION
Fixes the username bug in #83 and updates the manifest files to Manifest v3:

>We will begin disabling Manifest V2 extensions in pre-stable versions of Chrome (Dev, Canary, and Beta) as early as June 2024

https://developer.chrome.com/blog/resuming-the-transition-to-mv3